### PR TITLE
Use Candara fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ You can also generate a PDF of some simple lined pages:
 
 ## Limitations
 
-Probably only works on a Mac since it hardcodes the font path.
+The configuration uses the Candara font. On Windows it is usually installed at
+`C:\\Windows\\Fonts\\Candara.ttf`. If the fonts are elsewhere, edit
+`config.rb` to point to the correct location.
 
 ## Thanks
 

--- a/config.rb
+++ b/config.rb
@@ -5,13 +5,13 @@ COLUMN_COUNT = 4
 LIGHT_COLOR = 'AAAAAA'
 MEDIUM_COLOR = '888888'
 DARK_COLOR   = '000000'
-OSX_FONT_PATH = "/System/Library/Fonts/Supplemental/Futura.ttc"
+OSX_FONT_PATH = "C:\\Windows\\Fonts\\Candara.ttf"
 FONTS = {
-  'Futura' => {
-    normal: { file: OSX_FONT_PATH, font: 'Futura Medium' },
-    italic: { file: OSX_FONT_PATH, font: 'Futura Medium Italic' },
-    bold: { file: OSX_FONT_PATH, font: 'Futura Condensed ExtraBold' },
-    condensed: { file: OSX_FONT_PATH, font: 'Futura Condensed Medium' },
+  'Candara' => {
+    normal: { file: OSX_FONT_PATH, font: 'Candara' },
+    italic: { file: OSX_FONT_PATH, font: 'Candara Italic' },
+    bold: { file: OSX_FONT_PATH, font: 'Candara Bold' },
+    condensed: { file: OSX_FONT_PATH, font: 'Candara' },
   }
 }
 PAGE_SIZE = 'LETTER' # Could also do 'A4'


### PR DESCRIPTION
## Summary
- update `config.rb` to use Candara font paths on Windows
- note the Windows font location in README and drop the Mac-only note

## Testing
- `ruby -c config.rb`
- `ruby -c planner.rb`
- `ruby -c notes.rb`
- `ruby -c one-on-one.rb`
- `ruby -c shared.rb`

Bundler gems were not installed so running the scripts themselves failed.


------
https://chatgpt.com/codex/tasks/task_e_6866271c415c8330904b6ef9acd91776